### PR TITLE
Use pure Python implementation of 3DES to avoid pycrypto

### DIFF
--- a/sitelist.py
+++ b/sitelist.py
@@ -8,9 +8,9 @@ import argparse
 from xml.dom import minidom
 
 try:
-    from Crypto.Cipher import DES3
+    import pyDes
 except:
-    print "Crypto module required. Please install it via pip."
+    print "DES module required. Please install it via pip install pydes."
     sys.exit(1)
 
 def banner():
@@ -119,7 +119,7 @@ def decrypt(encoded):
     for i in range(0, len(decoded)):
         xored += chr(ord(decoded[i]) ^ xor_key[i % len(xor_key)])
 
-    cipher = DES3.new(key, DES3.MODE_ECB)
+    cipher = pyDes.triple_des(key, pyDes.ECB)
     decryptedString = cipher.decrypt(xored)
 
     password = ""


### PR DESCRIPTION
Figured I'd send this over so that people don't have to go through the nightmare of getting pycrypto setup on Windows due to some annoying bugs like https://stackoverflow.com/questions/41843266/microsoft-windows-python-3-6-pycrypto-installation-error/41843310#41843310 (plus others).